### PR TITLE
BDOG-2213 Update Vulnerabilities service to use summaries collection

### DIFF
--- a/app/uk/gov/hmrc/vulnerabilities/model/Vulnerability.scala
+++ b/app/uk/gov/hmrc/vulnerabilities/model/Vulnerability.scala
@@ -149,6 +149,8 @@ case class VulnerabilityOccurrence(
     service            : String,
     serviceVersion     : String,
     componentPathInSlug: String,
+    teams              : Seq[String],
+    envs               : Seq[String]
 )
 
 object VulnerabilityOccurrence {
@@ -156,6 +158,8 @@ object VulnerabilityOccurrence {
     ( (__ \ "service"         ).format[String]
       ~ (__ \ "serviceVersion").format[String]
       ~ (__ \ "componentPathInSlug").format[String]
+      ~ (__ \ "teams").format[Seq[String]]
+      ~ (__ \ "envs").format[Seq[String]]
       )(apply, unlift(unapply))
   }
 }

--- a/app/uk/gov/hmrc/vulnerabilities/model/Vulnerability.scala
+++ b/app/uk/gov/hmrc/vulnerabilities/model/Vulnerability.scala
@@ -136,7 +136,7 @@ object DistinctVulnerability {
       ~ (__ \ "description"               ).format[String]
       ~ (__ \ "fixedVersions"             ).formatNullable[Seq[String]]
       ~ (__ \ "references"                ).format[Seq[String]]
-      ~ (__ \ "published"                 ).format[Instant]
+      ~ (__ \ "publishedDate"             ).format[Instant]
       ~ (__ \ "assessment"                ).formatNullable[String]
       ~ (__ \ "curationStatus"            ).formatNullable[CurationStatus]
       ~ (__ \ "ticket"                    ).formatNullable[String]
@@ -146,9 +146,9 @@ object DistinctVulnerability {
 }
 
 case class VulnerabilityOccurrence(
-    service       : String,
-    serviceVersion: String,
-    componentPathInSlug: String
+    service            : String,
+    serviceVersion     : String,
+    componentPathInSlug: String,
 )
 
 object VulnerabilityOccurrence {
@@ -183,7 +183,7 @@ object VulnerabilitySummary {
 
       ((__ \ "distinctVulnerability").format[DistinctVulnerability]
         ~ (__ \ "occurrences"        ).format[Seq[VulnerabilityOccurrence]]
-        ~ (__ \ "teams"             ).format[Seq[String]]
+        ~ (__ \ "teams"              ).format[Seq[String]]
         ) (apply, unlift(unapply))
     }
 }

--- a/app/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitySummariesRepository.scala
+++ b/app/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitySummariesRepository.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.vulnerabilities.persistence
 
 import com.mongodb.client.model.Indexes
+import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.bson.{BsonArray, BsonDocument, conversions}
 import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions, Sorts}
 import uk.gov.hmrc.mongo.MongoComponent
@@ -55,35 +56,26 @@ class VulnerabilitySummariesRepository @Inject()(
             }
           ).flatten
 
-    def removeUnmatchedServices(service: String): conversions.Bson = {
-      service match {
-        case Quoted(s) => project(BsonDocument(
+    val pipeline: Seq[Bson] = Seq(
+      if(allFilters.isEmpty) None else Some(`match`(Filters.and(allFilters: _*))) ,
+      service.map(service => project(BsonDocument(
           "distinctVulnerability" -> "$distinctVulnerability",
           "teams"                 -> "$teams",
           "occurrences"           ->
             BsonDocument("$filter" -> BsonDocument(
               "input" -> "$occurrences",
               "as"    -> "o",
-              "cond"  -> BsonDocument("$eq" -> BsonArray("$$o.service", s))
+              "cond"  -> {
+                service match {
+                  case Quoted(s) => BsonDocument("$eq" -> BsonArray("$$o.service", s))
+                  case s => BsonDocument("$regexMatch" -> BsonDocument("input" -> "$$o.service", "regex" -> s))
+                }
+              }
             )
             )
         ))
-        case s => project(BsonDocument(
-          "distinctVulnerability" -> "$distinctVulnerability",
-          "teams"                 -> "$teams",
-          "occurrences"           ->
-            BsonDocument("$filter" -> BsonDocument(
-              "input" -> "$occurrences",
-              "as"    -> "o",
-              "cond"  -> BsonDocument("$regexMatch" -> BsonDocument("input" -> "$$o.service", "regex" -> s))
-            )
-            )
-        ))
-      }
-    }
-
-    def removeUnmatchedTeams(team: String): conversions.Bson =
-      project(BsonDocument(
+      ),
+      team.map(team => project(BsonDocument(
         "distinctVulnerability" -> "$distinctVulnerability",
         "teams"                 -> "$teams",
         "occurrences"           ->
@@ -93,24 +85,12 @@ class VulnerabilitySummariesRepository @Inject()(
             "cond"  -> BsonDocument("$in" -> BsonArray(team, "$$o.teams"))
           )
           )
-      ))
-
-    val pipelineSort = Seq(
-      sort(
+      ))),
+      Some(sort(
         Sorts.orderBy(Sorts.descending("distinctVulnerability.score"), Sorts.ascending("distinctVulnerability.id"))
-      )
-    )
+      ))
+    ).flatten
 
-    //Use pattern matching to execute either a find, or an aggregate pipeline - depending on the query params passed in.
-    //Pipeline required for service/team params, as need to filter out the occurrences that don't match
-    (team, service, allFilters) match {
-      case (_, _, Nil)              => collection.find().sort(
-        Sorts.orderBy(Sorts.descending("distinctVulnerability.score"), Sorts.ascending("distinctVulnerability.id"))).toFuture()
-      case (None, None, more)          => collection.find(Filters.and(more: _*)).sort(
-        Sorts.orderBy(Sorts.descending("distinctVulnerability.score"), Sorts.ascending("distinctVulnerability.id"))).toFuture()
-      case (None      , Some(service), more) => collection.aggregate(`match`(Filters.and(more: _*)) +: removeUnmatchedServices(service) +: pipelineSort).toFuture()
-      case (Some(team), None         , more) => collection.aggregate(`match`(Filters.and(more: _*)) +: removeUnmatchedTeams(team)       +: pipelineSort).toFuture()
-      case (Some(team), Some(service), more) => collection.aggregate(`match`(Filters.and(more: _*)) +: removeUnmatchedServices(service) +: removeUnmatchedTeams(team) +: pipelineSort).toFuture()
-    }
+    collection.aggregate(pipeline).toFuture()
   }
 }

--- a/app/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitySummariesRepository.scala
+++ b/app/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitySummariesRepository.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vulnerabilities.persistence
+
+import com.mongodb.client.model.Indexes
+import org.mongodb.scala.bson.{BsonArray, BsonDocument, conversions}
+import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions, Sorts}
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import org.mongodb.scala.model.Aggregates._
+import uk.gov.hmrc.vulnerabilities.model.VulnerabilitySummary
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class VulnerabilitySummariesRepository @Inject()(
+                                           mongoComponent: MongoComponent
+                                         )(implicit ec: ExecutionContext
+                                         ) extends PlayMongoRepository(
+  collectionName = "vulnerabilitySummaries",
+  mongoComponent = mongoComponent,
+  domainFormat   = VulnerabilitySummary.mongoFormat,
+  indexes        = Seq(
+    IndexModel(Indexes.ascending("occurrences.service"), IndexOptions().name("occurrences.service").background(true)),
+    IndexModel(Indexes.ascending("distinctVulnerability.id"), IndexOptions().name("distinctVulnerability.id").background(true)),
+    IndexModel(Indexes.ascending("teams"), IndexOptions().name("teams").background(true)),
+    IndexModel(Indexes.ascending("distinctVulnerability.curationStatus"), IndexOptions().name("distinctVulnerability.curationStatus").background(true)),
+  ),
+) {
+  def distinctVulnerabilitiesSummary(id: Option[String], curationStatus: Option[String], service: Option[String], team: Option[String]): Future[Seq[VulnerabilitySummary]] = {
+    val Quoted = """^\"(.*)\"$""".r
+
+    val allFilters = Seq(
+                  id.map(i => Filters.regex("distinctVulnerability.id", i.toUpperCase())),
+      curationStatus.map(r => Filters.equal("distinctVulnerability.curationStatus", r)),
+                team.map(t => Filters.equal("teams", t)),
+            service.map {
+              case Quoted(s) => Filters.equal("occurrences.service", s.toLowerCase())
+              case s         => Filters.regex("occurrences.service", s.toLowerCase())
+            }
+          ).flatten
+
+    def removeUnmatchedServices(service: String): conversions.Bson = {
+      service match {
+        case Quoted(s) => project(BsonDocument(
+          "distinctVulnerability" -> "$distinctVulnerability",
+          "teams"                 -> "$teams",
+          "occurrences"           ->
+            BsonDocument("$filter" -> BsonDocument(
+              "input" -> "$occurrences",
+              "as"    -> "o",
+              "cond"  -> BsonDocument("$eq" -> BsonArray("$$o.service", s))
+            )
+            )
+        ))
+        case s => project(BsonDocument(
+          "distinctVulnerability" -> "$distinctVulnerability",
+          "teams"                 -> "$teams",
+          "occurrences"           ->
+            BsonDocument("$filter" -> BsonDocument(
+              "input" -> "$occurrences",
+              "as"    -> "o",
+              "cond"  -> BsonDocument("$regexMatch" -> BsonDocument("input" -> "$$o.service", "regex" -> s))
+            )
+            )
+        ))
+      }
+    }
+
+    def removeUnmatchedTeams(team: String): conversions.Bson =
+      project(BsonDocument(
+        "distinctVulnerability" -> "$distinctVulnerability",
+        "teams"                 -> "$teams",
+        "occurrences"           ->
+          BsonDocument("$filter" -> BsonDocument(
+            "input" -> "$occurrences",
+            "as"    -> "o",
+            "cond"  -> BsonDocument("$in" -> BsonArray(team, "$$o.teams"))
+          )
+          )
+      ))
+
+    val pipelineSort = Seq(
+      sort(
+        Sorts.orderBy(Sorts.descending("distinctVulnerability.score"), Sorts.ascending("distinctVulnerability.id"))
+      )
+    )
+
+    //Use pattern matching to execute either a find, or an aggregate pipeline - depending on the query params passed in.
+    //Pipeline required for service/team params, as need to filter out the occurrences that don't match
+    (team, service, allFilters) match {
+      case (_, _, Nil)              => collection.find().sort(
+        Sorts.orderBy(Sorts.descending("distinctVulnerability.score"), Sorts.ascending("distinctVulnerability.id"))).toFuture()
+      case (None, None, more)          => collection.find(Filters.and(more: _*)).sort(
+        Sorts.orderBy(Sorts.descending("distinctVulnerability.score"), Sorts.ascending("distinctVulnerability.id"))).toFuture()
+      case (None      , Some(service), more) => collection.aggregate(`match`(Filters.and(more: _*)) +: removeUnmatchedServices(service) +: pipelineSort).toFuture()
+      case (Some(team), None         , more) => collection.aggregate(`match`(Filters.and(more: _*)) +: removeUnmatchedTeams(team)       +: pipelineSort).toFuture()
+      case (Some(team), Some(service), more) => collection.aggregate(`match`(Filters.and(more: _*)) +: removeUnmatchedServices(service) +: removeUnmatchedTeams(team) +: pipelineSort).toFuture()
+    }
+  }
+}

--- a/app/uk/gov/hmrc/vulnerabilities/service/VulnerabilitiesService.scala
+++ b/app/uk/gov/hmrc/vulnerabilities/service/VulnerabilitiesService.scala
@@ -18,24 +18,24 @@ package uk.gov.hmrc.vulnerabilities.service
 
 import uk.gov.hmrc.vulnerabilities.model.CurationStatus.ActionRequired
 import uk.gov.hmrc.vulnerabilities.model.{Vulnerability, VulnerabilitySummary}
-import uk.gov.hmrc.vulnerabilities.persistence.VulnerabilitiesRepository
+import uk.gov.hmrc.vulnerabilities.persistence.{VulnerabilitiesRepository, VulnerabilitySummariesRepository}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class VulnerabilitiesService @Inject() (
-  vulnerabilitiesRepository: VulnerabilitiesRepository,
+ vulnerabilitySummariesRepository: VulnerabilitySummariesRepository
 )(implicit val ec: ExecutionContext) {
 
   def countDistinctVulnerabilities(service: String): Future[Int] = {
     // adds quotes for regex exact match
     val serviceWithQuotes = Some(s"\"$service\"")
-    vulnerabilitiesRepository.distinctVulnerabilitiesSummary(None, Some(ActionRequired.asString), serviceWithQuotes, None)
+    vulnerabilitySummariesRepository.distinctVulnerabilitiesSummary(None, Some(ActionRequired.asString), serviceWithQuotes, None)
       .map(_.map(vs => vs.distinctVulnerability.id).toSet.size)
   }
 
   def distinctVulnerabilitiesSummary(vulnerability: Option[String], curationStatus: Option[String], service: Option[String], team: Option[String]): Future[Seq[VulnerabilitySummary]] = {
-    vulnerabilitiesRepository.distinctVulnerabilitiesSummary(vulnerability, curationStatus, service, team)
+    vulnerabilitySummariesRepository.distinctVulnerabilitiesSummary(vulnerability, curationStatus, service, team)
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,5 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.8.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.1.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.18")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "1.9.3")


### PR DESCRIPTION
1. By switching to use a collection which is already structured as required by the frontend - this significantly improves performance. Benchmark of 20 local executions with no filters applied showed:
	Old flat collection: ~1400ms response time
	New nested collection: ~410ms response time
(Both figures refer to backend only)

2. Note, an aggregation pipeline is still required, in order to filter out occurrences that don't contain the team/service. But pattern matching is used to only use a pipeline if needed, and to use the least amount of steps required.