### PR TITLE
BDOG-2182: Temporarily make the generatedDate field an Option, until …

### DIFF
--- a/app/uk/gov/hmrc/vulnerabilities/model/Vulnerability.scala
+++ b/app/uk/gov/hmrc/vulnerabilities/model/Vulnerability.scala
@@ -190,7 +190,7 @@ case class VulnerabilitySummary(
    distinctVulnerability: DistinctVulnerability,
    occurrences          : Seq[VulnerabilityOccurrence],
    teams                : Seq[String],
-   generatedDate        : Instant
+   generatedDate        : Option[Instant]
 )
 
 object VulnerabilitySummary {
@@ -202,7 +202,7 @@ object VulnerabilitySummary {
     ((__ \ "distinctVulnerability").format[DistinctVulnerability]
       ~ (__ \ "occurrences"        ).format[Seq[VulnerabilityOccurrence]]
       ~ (__ \ "teams"              ).format[Seq[String]]
-      ~ (__ \ "generatedDate"      ).format[Instant]
+      ~ (__ \ "generatedDate"      ).formatNullable[Instant]
       ) (apply, unlift(unapply))
     }
 
@@ -213,7 +213,7 @@ object VulnerabilitySummary {
     ((__ \ "distinctVulnerability").format[DistinctVulnerability]
       ~ (__ \ "occurrences"        ).format[Seq[VulnerabilityOccurrence]]
       ~ (__ \ "teams"              ).format[Seq[String]]
-      ~ (__ \ "generatedDate"      ).format[Instant]
+      ~ (__ \ "generatedDate"      ).formatNullable[Instant]
       ) (apply, unlift(unapply))
   }
 }

--- a/app/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitySummariesRepository.scala
+++ b/app/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitySummariesRepository.scala
@@ -60,7 +60,7 @@ class VulnerabilitySummariesRepository @Inject()(
       .find()
       .sort(Sorts.descending("generatedDate"))
       .headOption()
-      .map(_.map(_.generatedDate).getOrElse(defaultDate))
+      .map(_.flatMap(_.generatedDate).getOrElse(defaultDate))
 
   private implicit val tc = TransactionConfiguration.strict
 

--- a/app/uk/gov/hmrc/vulnerabilities/service/VulnerabilitiesService.scala
+++ b/app/uk/gov/hmrc/vulnerabilities/service/VulnerabilitiesService.scala
@@ -80,7 +80,7 @@ class VulnerabilitiesService @Inject() (
         ),
         occurrences           = occs.sortBy(o => (o.service, o.serviceVersion)),
         teams                 = occs.flatMap(_.teams).distinct.sorted,
-        generatedDate         = u.generatedDate
+        generatedDate         = Some(u.generatedDate)
       )
     }
 

--- a/it/uk/gov/hmrc/vulnerabilities/HappyPathIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/vulnerabilities/HappyPathIntegrationSpec.scala
@@ -122,7 +122,7 @@ class HappyPathIntegrationSpec
           VulnerabilityOccurrence("Service1","0.836.0","Service1-0.836.0/some/physical/path",Seq("Team1", "Team2"),Seq("production"),"gav://com.testxml.test.core:test-bind","1.5.9")
         ),
         teams = List("Team1", "Team2"),
-        generatedDate = StubResponses.startOfYear
+        generatedDate = Some(StubResponses.startOfYear)
       )
 
       //Test occurs below
@@ -133,7 +133,7 @@ class HappyPathIntegrationSpec
         .url(resource("/vulnerabilities/api/vulnerabilities/testResult"))
         .get.futureValue
 
-      val result = response.json.as[Seq[VulnerabilitySummary]].map(_.copy(generatedDate = StubResponses.startOfYear))
+      val result = response.json.as[Seq[VulnerabilitySummary]].map(_.copy(generatedDate = Some(StubResponses.startOfYear)))
       //update the results generated date as otherwise it would be dynamic - it would be the time of test
 
       result.length shouldBe 1

--- a/it/uk/gov/hmrc/vulnerabilities/SomeReportsAlreadyExistIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/vulnerabilities/SomeReportsAlreadyExistIntegrationSpec.scala
@@ -121,7 +121,7 @@ class SomeReportsAlreadyExistIntegrationSpec
           VulnerabilityOccurrence("Service1","0.836.0","Service1-0.836.0/some/physical/path",Seq("Team1", "Team2"),Seq("production"),"gav://com.testxml.test.core:test-bind","1.5.9")
         ),
         teams = List("Team1", "Team2"),
-        generatedDate = StubResponses.startOfYear
+        generatedDate = Some(StubResponses.startOfYear)
       )
 
       val expectedResult2 = VulnerabilitySummary(
@@ -142,7 +142,7 @@ class SomeReportsAlreadyExistIntegrationSpec
           VulnerabilityOccurrence("Service5","5.0.4","Service5-5.0.4/some/physical/path",Seq(),Seq("staging", "production"),"gav://com.testxml.test.core:test-bind","1.5.9"),
         ),
         teams = Seq(),
-        generatedDate = StubResponses.startOfYear
+        generatedDate = Some(StubResponses.startOfYear)
       )
 
       //Test occurs below
@@ -154,7 +154,7 @@ class SomeReportsAlreadyExistIntegrationSpec
         .url(resource("/vulnerabilities/api/vulnerabilities/testResult"))
         .get.futureValue
 
-      val result = response.json.as[Seq[VulnerabilitySummary]].map(_.copy(generatedDate = StubResponses.startOfYear)).sortBy(_.distinctVulnerability.id)
+      val result = response.json.as[Seq[VulnerabilitySummary]].map(_.copy(generatedDate = Some(StubResponses.startOfYear))).sortBy(_.distinctVulnerability.id)
       //update the results generated date as otherwise it would be dynamic - it would be the time of test
 
       result.length shouldBe 2

--- a/test/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitiesRepositorySpec.scala
+++ b/test/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitiesRepositorySpec.scala
@@ -80,9 +80,9 @@ class VulnerabilitiesRepositorySpec
     "default sort by descending score and ascending id" in new Setup {
       repository.collection.insertMany(Seq(vulnerabilitySummary1, vulnerabilitySummary2, vulnerabilitySummary3)).toFuture().futureValue
 
-      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(0), Seq(expectedOccurrences(0), expectedOccurrences(5)), Seq("team1", "team2"), oneMinAgo)
-      val expected2 = VulnerabilitySummary(expectedDistinctVulnerabilities(1), Seq(expectedOccurrences(6), expectedOccurrences(1)), Seq("team1", "team2"), now)
-      val expected3 = VulnerabilitySummary(expectedDistinctVulnerabilities(2), Seq(expectedOccurrences(2), expectedOccurrences(3), expectedOccurrences(4)), Seq("team1"), fourDaysAgo)
+      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(0), Seq(expectedOccurrences(0), expectedOccurrences(5)), Seq("team1", "team2"), Some(oneMinAgo))
+      val expected2 = VulnerabilitySummary(expectedDistinctVulnerabilities(1), Seq(expectedOccurrences(6), expectedOccurrences(1)), Seq("team1", "team2"), Some(now))
+      val expected3 = VulnerabilitySummary(expectedDistinctVulnerabilities(2), Seq(expectedOccurrences(2), expectedOccurrences(3), expectedOccurrences(4)), Seq("team1"), Some(fourDaysAgo))
 
       val results = repository.distinctVulnerabilitiesSummary(None, None, None, None).futureValue
       val resultsSorted = results.map(res => res.copy(teams = res.teams.sorted, occurrences = res.occurrences.sortBy(_.service)))
@@ -95,7 +95,7 @@ class VulnerabilitiesRepositorySpec
       repository.collection.insertMany(Seq(vulnerabilitySummary1, vulnerabilitySummary2, vulnerabilitySummary3)).toFuture().futureValue
 
 
-      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(2), Seq(expectedOccurrences(2), expectedOccurrences(3), expectedOccurrences(4)), Seq("team1"), fourDaysAgo)
+      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(2), Seq(expectedOccurrences(2), expectedOccurrences(3), expectedOccurrences(4)), Seq("team1"), Some(fourDaysAgo))
 
       val results = repository.distinctVulnerabilitiesSummary(id = Some("XRAY"), None, None, None).futureValue
       val resultsSorted = results.map(res => res.copy(teams = res.teams.sorted, occurrences = res.occurrences.sortBy(_.service)))
@@ -108,8 +108,8 @@ class VulnerabilitiesRepositorySpec
     "filter by curationStatus" in new Setup {
       repository.collection.insertMany(Seq(vulnerabilitySummary1, vulnerabilitySummary2, vulnerabilitySummary3)).toFuture().futureValue
 
-      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(0), Seq(expectedOccurrences(0), expectedOccurrences(5)), Seq("team1", "team2"), oneMinAgo)
-      val expected2 = VulnerabilitySummary(expectedDistinctVulnerabilities(2), Seq(expectedOccurrences(2), expectedOccurrences(3), expectedOccurrences(4)), Seq("team1"), fourDaysAgo)
+      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(0), Seq(expectedOccurrences(0), expectedOccurrences(5)), Seq("team1", "team2"), Some(oneMinAgo))
+      val expected2 = VulnerabilitySummary(expectedDistinctVulnerabilities(2), Seq(expectedOccurrences(2), expectedOccurrences(3), expectedOccurrences(4)), Seq("team1"), Some(fourDaysAgo))
 
       val results = repository.distinctVulnerabilitiesSummary(None, curationStatus = Some(CurationStatus.ActionRequired.asString), None, None).futureValue
       val resultsSorted = results.map(res => res.copy(teams = res.teams.sorted, occurrences = res.occurrences.sortBy(_.service)))
@@ -121,7 +121,7 @@ class VulnerabilitiesRepositorySpec
     "filter by service name" in new Setup {
       repository.collection.insertMany(Seq(vulnerabilitySummary1, vulnerabilitySummary2, vulnerabilitySummary3)).toFuture().futureValue
 
-      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(0), Seq(expectedOccurrences(0)), Seq("team1", "team2"), generatedDate = oneMinAgo)
+      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(0), Seq(expectedOccurrences(0)), Seq("team1", "team2"), generatedDate = Some(oneMinAgo))
 
       val results = repository.distinctVulnerabilitiesSummary(None, None, service = Some("ice1"), None).futureValue
       val resultsSorted = results.map(res => res.copy(teams = res.teams.sorted, occurrences = res.occurrences.sortBy(_.service)))
@@ -133,8 +133,8 @@ class VulnerabilitiesRepositorySpec
     "filter by team" in new Setup {
       repository.collection.insertMany(Seq(vulnerabilitySummary1, vulnerabilitySummary2, vulnerabilitySummary3)).toFuture().futureValue
 
-      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(0), Seq(expectedOccurrences(5)), Seq("team1", "team2"), oneMinAgo)
-      val expected2 = VulnerabilitySummary(expectedDistinctVulnerabilities(1), Seq(expectedOccurrences(6)), Seq("team1", "team2"), now)
+      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(0), Seq(expectedOccurrences(5)), Seq("team1", "team2"), Some(oneMinAgo))
+      val expected2 = VulnerabilitySummary(expectedDistinctVulnerabilities(1), Seq(expectedOccurrences(6)), Seq("team1", "team2"), Some(now))
 
       val results = repository.distinctVulnerabilitiesSummary(None, None, None, team = Some("team2")).futureValue
       val resultsSorted = results.map(res => res.copy(teams = res.teams.sorted, occurrences = res.occurrences.sortBy(_.service)))
@@ -146,7 +146,7 @@ class VulnerabilitiesRepositorySpec
     "filter by all four parameters" in new Setup {
       repository.collection.insertMany(Seq(vulnerabilitySummary1, vulnerabilitySummary2, vulnerabilitySummary3)).toFuture().futureValue
 
-      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(2), Seq(expectedOccurrences(4)), Seq("team1"), fourDaysAgo)
+      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(2), Seq(expectedOccurrences(4)), Seq("team1"), Some(fourDaysAgo))
 
       val results1 = repository.distinctVulnerabilitiesSummary(id = Some("XRAY"), curationStatus = Some(CurationStatus.ActionRequired.asString), service = Some("3"), team = Some("team2")).futureValue
       val results2 = repository.distinctVulnerabilitiesSummary(id = Some("XRAY"), curationStatus = Some(CurationStatus.ActionRequired.asString), service = Some("3"), team = Some("team1")).futureValue
@@ -173,7 +173,7 @@ class VulnerabilitiesRepositorySpec
     "Do an exact match on service when searchTerm is quoted" in new Setup {
       repository.collection.insertMany(Seq(vulnerabilitySummary1, vulnerabilitySummary2, vulnerabilitySummary3)).toFuture().futureValue
 
-      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(2), Seq(expectedOccurrences(2), expectedOccurrences(3)), Seq("team1"), fourDaysAgo)
+      val expected1 = VulnerabilitySummary(expectedDistinctVulnerabilities(2), Seq(expectedOccurrences(2), expectedOccurrences(3)), Seq("team1"), Some(fourDaysAgo))
       val results = repository.distinctVulnerabilitiesSummary(None, None, Some("\"service3\""), None).futureValue
 
       val resultsSorted = results.map(res => res.copy(teams = res.teams.sorted, occurrences = res.occurrences.sortBy(_.service)))
@@ -249,7 +249,7 @@ class VulnerabilitiesRepositorySpec
           VulnerabilityOccurrence(service = "service6", serviceVersion = "2.55", componentPathInSlug = "apache:x", teams = Seq("team2"), envs = Seq("staging", "production"), vulnerableComponentName = "component1.1", vulnerableComponentVersion = "0.8")
         ),
         teams = Seq("team1", "team2"),
-        generatedDate = oneMinAgo
+        generatedDate = Some(oneMinAgo)
       )
 
     lazy val vulnerabilitySummary2 =
@@ -275,7 +275,7 @@ class VulnerabilitiesRepositorySpec
           VulnerabilityOccurrence(service = "helloWorld", serviceVersion = "2.51", componentPathInSlug = "apache:y", teams = Seq("team1", "team2"), envs = Seq("qa"), vulnerableComponentName = "component2", vulnerableComponentVersion = "2.0")
         ),
         teams = Seq("team1", "team2"),
-        generatedDate = now
+        generatedDate = Some(now)
       )
 
     lazy val vulnerabilitySummary3 = VulnerabilitySummary(
@@ -301,7 +301,7 @@ class VulnerabilitiesRepositorySpec
         VulnerabilityOccurrence(service = "service33",serviceVersion = "3",componentPathInSlug = "e",teams = Seq("team1"), envs =Seq("staging", "production"), vulnerableComponentName = "component3", vulnerableComponentVersion = "3.0"),
       ),
       teams = Seq("team1"),
-      generatedDate = fourDaysAgo
+      generatedDate = Some(fourDaysAgo)
     )
 
   }

--- a/test/uk/gov/hmrc/vulnerabilities/service/VulnerabilitiesServiceSpec.scala
+++ b/test/uk/gov/hmrc/vulnerabilities/service/VulnerabilitiesServiceSpec.scala
@@ -133,7 +133,7 @@ class VulnerabilitiesServiceSpec extends AnyWordSpec with Matchers {
         )
       ),
       teams = Seq("Team1", "TeamA"),
-      generatedDate = UnrefinedVulnerabilitySummariesData.now
+      generatedDate = Some(UnrefinedVulnerabilitySummariesData.now)
       )
 
     val vuln2 = VulnerabilitySummary(
@@ -160,7 +160,7 @@ class VulnerabilitiesServiceSpec extends AnyWordSpec with Matchers {
         )
       ),
       teams = Seq("Team1", "Team4", "TeamA", "TeamF"),
-      generatedDate = UnrefinedVulnerabilitySummariesData.now
+      generatedDate = Some(UnrefinedVulnerabilitySummariesData.now)
     )
 
     val vuln3 = VulnerabilitySummary(
@@ -184,7 +184,7 @@ class VulnerabilitiesServiceSpec extends AnyWordSpec with Matchers {
         ),
       ),
       teams = Seq.empty,
-      generatedDate = UnrefinedVulnerabilitySummariesData.now
+      generatedDate = Some(UnrefinedVulnerabilitySummariesData.now)
     )
 
   }


### PR DESCRIPTION
…rolled out in live.

When rolling the scheduler out to labs, two issues were noted:
1. The scheduler did not run automatically, I had to kick it off manually via an endpoint. This is because the existing vulnerabilitySummaries data does not contain the generatedDate field - so the initial scheduler check of {is the most recent data older than 7 days} could never run, due to a JsonParseError.
2. Once the process had been kicked off manually, the page was inaccessible from Catalogue labs - again due to a JSON parse error, caused by the generatedDate field not being an option.

This is a temporary change - as once this has been rolled out to live - there is no good reason for this field to be optional.