### PR TITLE
BDOG-2490 - Fix filtering bug

### DIFF
--- a/app/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitySummariesRepository.scala
+++ b/app/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitySummariesRepository.scala
@@ -86,19 +86,30 @@ class VulnerabilitySummariesRepository @Inject()(
   ): Future[Seq[VulnerabilitySummary]] = {
     val Quoted = """^\"(.*)\"$""".r
 
-    val allFilters = Seq(
-      id.map(i => Filters.regex("distinctVulnerability.id", i.toUpperCase())),
-      curationStatus.map(r => Filters.equal("distinctVulnerability.curationStatus", r)),
-      team.map(t => Filters.equal("teams", t)),
-      component.map(c => Filters.regex("distinctVulnerability.vulnerableComponentName", c.toLowerCase())),
+    //Applying these filters together inside an elem match will ensure that we only return documents with an occurrence
+    //containing both the service AND the team (if both are specified). Without the elemMatch, Mongo will do an OR.
+    val occurrenceFilters: Seq[Bson] = Seq(
       service.map {
-        case Quoted(s) => Filters.equal("occurrences.service", s.toLowerCase())
-        case s => Filters.regex("occurrences.service", s.toLowerCase())
-      }
+        case Quoted(s) => Filters.equal("service", s.toLowerCase())
+        case s => Filters.regex("service", s.toLowerCase())
+      },
+      team.map(t => Filters.equal("teams", t))
     ).flatten
 
+    val dvFilters: Seq[Bson] = Seq(
+      id.map            (i => Filters.regex("distinctVulnerability.id", i.toUpperCase())),
+      curationStatus.map(r => Filters.equal("distinctVulnerability.curationStatus", r)),
+      team.map          (t => Filters.equal("teams", t)),
+      component.map     (c => Filters.regex("distinctVulnerability.vulnerableComponentName", c.toLowerCase())),
+      if(occurrenceFilters.isEmpty) None else Some(Filters.elemMatch("occurrences", Filters.and(occurrenceFilters: _*)))
+    ).flatten
+
+
+
     val pipeline: Seq[Bson] = Seq(
-      if(allFilters.isEmpty) None else Some(`match`(Filters.and(allFilters: _*))) ,
+      //1. Apply all filters at the top level
+      if(dvFilters.isEmpty) None else Some(`match`(Filters.and(dvFilters: _*))) ,
+      //2. Remove elements from occurences array that don't match the team filter
       service.map(service => project(BsonDocument(
           "distinctVulnerability" -> "$distinctVulnerability",
           "teams"                 -> "$teams",
@@ -114,9 +125,9 @@ class VulnerabilitySummariesRepository @Inject()(
               }
             )),
           "generatedDate"         -> "$generatedDate"
-
         ))
       ),
+      //3. Remove elements from occurences array that don't match the service filter
       team.map(team => project(BsonDocument(
         "distinctVulnerability" -> "$distinctVulnerability",
         "teams"                 -> "$teams",
@@ -128,6 +139,7 @@ class VulnerabilitySummariesRepository @Inject()(
           )),
         "generatedDate"         -> "$generatedDate"
       ))),
+      //4. Sort
       Some(sort(
         Sorts.orderBy(Sorts.descending("distinctVulnerability.score"), Sorts.ascending("distinctVulnerability.id"))
       ))

--- a/test/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitiesRepositorySpec.scala
+++ b/test/uk/gov/hmrc/vulnerabilities/persistence/VulnerabilitiesRepositorySpec.scala
@@ -196,6 +196,18 @@ class VulnerabilitiesRepositorySpec
       resultsSorted.head.occurrences.length mustBe 2 //Shouldn't pick up 'Service33'
 
     }
+
+    "return an empty list when given service and team filters that each match seperate occurrences, but don't both match the same occurrence" in new Setup {
+      val expected = Seq.empty
+
+      repository.collection.insertMany(
+        Seq(vulnerabilitySummary1, vulnerabilitySummary2, vulnerabilitySummary3)
+      ).toFuture().futureValue
+
+      val res = repository.distinctVulnerabilitiesSummary(id = None, curationStatus = None, service = Some("service2"), team = Some("team2"), component = None).futureValue
+      res mustBe empty
+
+    }
   }
 
   "vulnerabilitiesCount" must {


### PR DESCRIPTION
Bug description:
Filtering by both serviceName & teamName
results in a vulnerability being returned if occurrenceA contains the serviceName and occurenceB contains the teamName. It correctly filters both occurrences out when it returns the result, however it shouldn’t return the vulnerability at all.

Fixes:
1. We only filtered by team at the top-level, we now also filter by team at the occurrences array level.
2. We use elemMatch in order to ensure mongo does an AND query rather than an OR query on the array.