### PR TITLE
BDOG-2491 Set replaceIndexes to true for rawReports repository

### DIFF
--- a/app/uk/gov/hmrc/vulnerabilities/persistence/RawReportsRepository.scala
+++ b/app/uk/gov/hmrc/vulnerabilities/persistence/RawReportsRepository.scala
@@ -43,7 +43,8 @@ configuration: Configuration
     collectionName = "rawReports",
     mongoComponent = mongoComponent,
     domainFormat   = Report.mongoFormat,
-    indexes        = Seq(IndexModel(Indexes.descending("generatedDate"), IndexOptions().name("generatedDate").background(true).expireAfter(2 * 365, TimeUnit.DAYS)))
+    indexes        = Seq(IndexModel(Indexes.descending("generatedDate"), IndexOptions().name("generatedDate").background(true).expireAfter(2 * 365, TimeUnit.DAYS))),
+    replaceIndexes = true
 )
     {
       private val dataCutOff = configuration.get[FiniteDuration]("data.refresh-cutoff").toMillis.toInt


### PR DESCRIPTION
Attempting to create a TTL on an already indexed field results in an IndexConflictException.

This forces the index to be dropped and recreated.