### PR TITLE
BDOG-2702: Upgrade HMRC Mongo library

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,7 +6,7 @@ import sbt._
 object AppDependencies {
 
   private val bootstrapPlayVersion = "7.15.0"
-  private val hmrcMongoPlayVersion = "1.1.0"
+  private val hmrcMongoPlayVersion = "1.3.0"
   private val alpakkaVersion = "4.0.0"
 
   val compile = Seq(


### PR DESCRIPTION
After the Mongo AWS IAM auth changes, we need more than 2 seconds for Mongo to timeout, which is what the HMRC Mongo library 1.1.0 version has. Newer versions set that up to 5 seconds, which is ok.